### PR TITLE
Update source uri of safetyapp

### DIFF
--- a/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
+++ b/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
@@ -2,7 +2,7 @@ SUMMARY = "IPC by pipe for AGL cluster demo safety workload"
 DESCRIPTION = "Jochen layers it on ^^"
 
 #that seems to be necessary, the license here makes no sense, I just fumbled it so it would compile ;)
-LICENSE="GPL2"
+LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/elisa-tech/wg-automotive-safety-app.git;branch=control_pipe;protocol=https;"

--- a/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
+++ b/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
@@ -5,8 +5,7 @@ DESCRIPTION = "Jochen layers it on ^^"
 LICENSE="GPL2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-#Once we have sorted out the repo location issue, this will move there
-SRC_URI = "git://github.com/Jochen-Kall/Safety-app.git;branch=control_pipe;protocol=https;"
+SRC_URI = "git://github.com/elisa-tech/wg-automotive-safety-app.git;branch=control_pipe;protocol=https;"
 
 SRCREV = "8db75d886c915efc16e481e3fb63a09fd6e10eb6"
 

--- a/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
+++ b/meta-elisa-demo/recipes-elisa/pipe-demo/pipe-demo.bb
@@ -21,6 +21,10 @@ SRC_URI += "file://safety-app.service"
 
 DEPENDS += "ncurses"
 
+# Build will break if AGL either disables softdog
+# or change to CONFIG_SOFT_WATCHDOG=y
+RDEPENDS_${PN} += "kernel-module-softdog"
+
 #Package version
 PV = "1.0+git${SRCPV}"
 


### PR DESCRIPTION
3 changes:
1) Update source uri
2) The incorrect license was giving warning in build logs
3) `RDEPENDS` on softdog module as suggested by @dl9pf