### PR TITLE
Fix kernel config cleanup

### DIFF
--- a/bsp/meta-elisa-bsp-qemu/conf/layer.conf
+++ b/bsp/meta-elisa-bsp-qemu/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-elisa-bsp-qemu"
 BBFILE_PATTERN_meta-elisa-bsp-qemu = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-elisa-bsp-qemu = "10"
+BBFILE_PRIORITY_meta-elisa-bsp-qemu = "71"
 
 LAYERDEPENDS_meta-elisa-bsp-qemu = "core"
 LAYERSERIES_COMPAT_meta-elisa-bsp-qemu = "dunfell"

--- a/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto/cleanup.cfg
+++ b/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto/cleanup.cfg
@@ -84,7 +84,6 @@
 # CONFIG_USB_SERIAL is not set
 # CONFIG_VFAT_FS is not set
 # CONFIG_VIRTIO_BALLOON is not set
-# CONFIG_VIRTIO_BLK is not set
 # CONFIG_VIRTIO_CONSOLE is not set
 # CONFIG_CRYPTO_DEV_VIRTIO is not set
 # CONFIG_VIRTIO_MMIO is not set

--- a/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
-SRC_URI += "file://i6300-wdog.cfg file://cleanup.cfg"
+SRC_URI_append = " file://i6300-wdog.cfg file://cleanup.cfg"


### PR DESCRIPTION
The bsp layer had the least priority and so was applied first which
was then getting modified by the kernel configs from agl and poky. So,
the cleanup was having almost no affect. It should be applied last, after
all the other configs have been applied.