### PR TITLE
Re-enable kernel cleanups

### DIFF
--- a/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto/cleanup.cfg
+++ b/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto/cleanup.cfg
@@ -3,7 +3,6 @@
 # CONFIG_SERIAL_8250_DW is not set
 # CONFIG_X86_ACPI_CPUFREQ is not set
 # CONFIG_JOYSTICK_ADI is not set
-# CONFIG_PACKET is not set
 # CONFIG_CRYPTO_ARC4 is not set
 # CONFIG_ATA_GENERIC is not set
 # CONFIG_ATA_PIIX is not set

--- a/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/bsp/meta-elisa-bsp-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto:"
 
-SRC_URI:append = " file://i6300-wdog.cfg"
+SRC_URI:append = " file://i6300-wdog.cfg file://cleanup.cfg file://cleanup_2.cfg"
 


### PR DESCRIPTION
CONFIG_PACKET is needed for the new CAN and can not be removed from the kernel config.

The build and test pipeline on CI is at https://gitlab.com/elisa-tech/meta-elisa-ci/-/pipelines/718207983