### PR TITLE
Add information about the addition and benfit of SSTATE to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Depending on the distribution, the following packages may also have to be instal
 	<pre><code>
 	<b>AGL_RELEASE/build></b> echo 'SSTATE_MIRRORS += "file://.* https://elisa-builder-00.iol.unh.edu/sstate/needlefish/PATH"' >> config/local.conf
 	</code></pre>
-	Using the SSTATE can reduce the build time considerably.
+	Using the sstate can reduce the build time considerably.
 
 5) Build the elisa-cluster-demo-platform target.
 	<pre><code>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ Depending on the distribution, the following packages may also have to be instal
 	<pre><code>
 	<b>AGL_RELEASE></b> source meta-agl/scripts/aglsetup.sh -f elisa-cluster-demo
 	</code></pre>
-	Build the elisa-cluster-demo-platform target.
+
+4) [Optional, but recommended] Configure the build to utilize ELISA's sstate mirror for prebuild packages.
+	<pre><code>
+	<b>AGL_RELEASE/build></b> echo 'SSTATE_MIRRORS += "file://.* https://elisa-builder-00.iol.unh.edu/sstate/needlefish/PATH"' >> config/local.conf
+	</code></pre>
+	Using the SSTATE can reduce the build time considerably.
+
+5) Build the elisa-cluster-demo-platform target.
 	<pre><code>
 	<b>AGL_RELEASE/build></b> bitbake elisa-cluster-demo-platform   (to generate the image)
 	</code></pre>


### PR DESCRIPTION
This PR adds an optional step to the build instructions in the README, describing how to configure the build for SSTATE usage.